### PR TITLE
Fix spelling and formatting issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ Quickly prototype and build the Phaser game you want to make! Develop in Phaser 
 
 This project is under development. The goal is to start with a boilerplate, but transition into a scaffold with various development tools. Many dev tools are here now, but many are yet to come. Examples are the bundle analysis and complexity analysis.
 
-This project can be used right now as a boilerplate, even without the eventual scaffolding features. It is a complete build using all the latest versions of Webpack, Babel and Phaser, and has an idiomatic project structure. Just follow the `Quickly Start` Instrructions!
+This project can be used right now as a boilerplate, even without the eventual scaffolding features. It is a complete build using all the latest versions of Webpack, Babel and Phaser, and has an idiomatic project structure. Just follow the `Quickly Start` instructions!
 
-# Features
-
---
+## Features
 
 -   Webpack 4
 -   babel 7 +
@@ -30,19 +28,19 @@ This project can be used right now as a boilerplate, even without the eventual s
 -   Project Complexity analysis `yarn complexity-report`
 -   Tilemap processing (extrusion and minification)
 
-# Quickly start
+## Quickly Start
 
 1.  Clone the repo
 2.  `yarn install`
 3.  `yarn start`
 
-#Play the Demo!
+## Play the Demo!
 
 The work in progress is here:
 🕹️[Working Example Of Create Phaser App](https://simiancraft.github.io/create-phaser-app/)
 
 Click to begin.
-Its currently a simple level, but soon will eventually integrate examples of level triggers, create behavior, and Game UI.
+It's currently a simple level, but soon will eventually integrate examples of level triggers, create behavior, and Game UI.
 
 Locomotion:
 


### PR DESCRIPTION
Noticed a typo and what looked to be a couple markdown formatting issues.

Before the movement controls there's also this bitin

> but soon will eventually integrate examples

I would recommend just picking one (soon or eventually) and using it.

- ... but soon will integrate examples ...
- ... but will eventually integrate examples ...