### PR TITLE
Fix to event listener memory leak

### DIFF
--- a/src/sprites/player/animation-sequencer.js
+++ b/src/sprites/player/animation-sequencer.js
@@ -38,7 +38,7 @@ export default class AnimationSequencer {
   sequence(name) {
     return new Promise((resolve, reject) => {
       this.entity.anims.play(name, true);
-      this.entity.on(
+      this.entity.once(
         'animationcomplete',
         (animation, frame) => {
           resolve(name);


### PR DESCRIPTION
Was taking a look at your code because I love how you organize the behaviors in an FSM. But I realized that the way you are handling animations, though it probably works, will eventually cause issues (a memory leak of sorts)

https://github.com/simiancraft/create-phaser-app/blob/master/src/sprites/player/animation-sequencer.js#L38-L49

Whenever you run an animation sequence, you are adding a new listener to the animation. This doesn't cause visible bugs because you are in a promise that which enforces that it in only resolved once. But your listener list keeps growing and growing. This will fix the memory leak, and align with what you intended. 
